### PR TITLE
Fix SSL Policies misuse in our GCP projects

### DIFF
--- a/gcp-k8s-public-app/main.tf
+++ b/gcp-k8s-public-app/main.tf
@@ -64,7 +64,7 @@ resource "kubernetes_manifest" "frontend_config" {
       redirectToHttps = {
         enabled = true
       }
-      sslPolicy = "${var.name}-ssl-policy"
+      sslPolicy = "${var.project}-monom-ssl-policy" // Makes use of project's default SSL policy
     }
   }
 }
@@ -73,13 +73,6 @@ resource "google_compute_global_address" "this" {
   name         = var.name
   project      = var.project
   address_type = "EXTERNAL"
-}
-
-resource "google_compute_ssl_policy" "this" {
-  name            = "${var.name}-ssl-policy"
-  project         = var.project
-  profile         = "MODERN"
-  min_tls_version = "TLS_1_2"
 }
 
 data "aws_route53_zone" "this" {

--- a/gcp-k8s-public-app/main.tf
+++ b/gcp-k8s-public-app/main.tf
@@ -64,7 +64,7 @@ resource "kubernetes_manifest" "frontend_config" {
       redirectToHttps = {
         enabled = true
       }
-      sslPolicy = "${var.project}-monom-ssl-policy" // Makes use of project's default SSL policy
+      sslPolicy = "gke-ingress-ssl-policy"
     }
   }
 }

--- a/project/main.tf
+++ b/project/main.tf
@@ -66,3 +66,11 @@ resource "google_project_iam_member" "conditional" {
     expression  = each.value.expression
   }
 }
+
+// Creates a default SSL policy for the project. This is going to be used by Ingress objetcts
+resource "google_compute_ssl_policy" "this" {
+  name            = "${var.project}-monom-ssl-policy"
+  project         = var.project
+  profile         = "MODERN"
+  min_tls_version = "TLS_1_2"
+}

--- a/project/main.tf
+++ b/project/main.tf
@@ -66,11 +66,3 @@ resource "google_project_iam_member" "conditional" {
     expression  = each.value.expression
   }
 }
-
-// Creates a default SSL policy for the project. This is going to be used by Ingress objetcts
-resource "google_compute_ssl_policy" "this" {
-  name            = "${var.project}-monom-ssl-policy"
-  project         = var.project
-  profile         = "MODERN"
-  min_tls_version = "TLS_1_2"
-}


### PR DESCRIPTION
Remove resource **google_ssl_policy** from *gcp-k8s-public-app*. Now, there is a common SSL policy for each GCP project, that will be used by every frontend config asociated to an Ingress object.