### PR TITLE
feat: upgrade k8s and vpc, gcp-k8s-public-app doesn't use kubernetes-…

### DIFF
--- a/gcp-k8s-public-app/main.tf
+++ b/gcp-k8s-public-app/main.tf
@@ -1,7 +1,5 @@
 
 resource "kubernetes_manifest" "managed_certificate" {
-  provider = kubernetes-alpha
-
   manifest = {
     apiVersion = "networking.gke.io/v1"
     kind       = "ManagedCertificate"
@@ -17,9 +15,8 @@ resource "kubernetes_manifest" "managed_certificate" {
   }
 }
 
-resource "kubernetes_ingress" "this" {
-  provider = kubernetes
-  count    = var.ingress == true ? 1 : 0
+resource "kubernetes_ingress_v1" "this" {
+  count = var.ingress == true ? 1 : 0
 
   metadata {
     name      = var.name
@@ -41,8 +38,12 @@ resource "kubernetes_ingress" "this" {
       http {
         path {
           backend {
-            service_name = var.service_name
-            service_port = var.service_port
+            service {
+              name = var.service_name
+              port {
+                number = var.service_port
+              }
+            }
           }
         }
       }
@@ -51,8 +52,6 @@ resource "kubernetes_ingress" "this" {
 }
 
 resource "kubernetes_manifest" "frontend_config" {
-  provider = kubernetes-alpha
-
   manifest = {
     apiVersion = "networking.gke.io/v1beta1"
     kind       = "FrontendConfig"

--- a/gcp-k8s-public-app/versions.tf
+++ b/gcp-k8s-public-app/versions.tf
@@ -1,16 +1,13 @@
 terraform {
   required_providers {
-    kubernetes-alpha = {
-      source  = "hashicorp/kubernetes-alpha"
-      version = "~> 0.5.0"
+    kubernetes = {
+      source = "hashicorp/kubernetes"
     }
     google = {
-      source  = "hashicorp/google"
-      version = "~> 3.78.0"
+      source = "hashicorp/google"
     }
     cloudflare = {
-      source  = "cloudflare/cloudflare"
-      version = "3.22.0"
+      source = "cloudflare/cloudflare"
     }
   }
 }

--- a/k8s-gke/main.tf
+++ b/k8s-gke/main.tf
@@ -10,7 +10,7 @@ locals {
 
 module "gke" {
   source  = "terraform-google-modules/kubernetes-engine/google//modules/beta-public-cluster-update-variant"
-  version = "~> 16.0.1"
+  version = "~> 23.0.0"
 
   project_id = var.project
   name       = var.gke_name
@@ -41,6 +41,7 @@ module "gke" {
     {
       name              = "pool-01"
       machine_type      = var.node_pool_machine_type
+      image_type        = "COS_CONTAINERD"
       disk_size_gb      = 50
       node_count        = var.node_autoscaling == false ? var.node_count : null
       min_count         = var.node_autoscaling == true ? var.node_pool_min_count : null

--- a/k8s-vpc/main.tf
+++ b/k8s-vpc/main.tf
@@ -4,7 +4,7 @@ locals {
 
 module "vpc" {
   source  = "terraform-google-modules/network/google"
-  version = "~> 3.1"
+  version = "~> 5.2.0"
 
   project_id   = var.project
   network_name = var.vpc_name


### PR DESCRIPTION
…alpha

terraform state replace-provider hashicorp/kubernetes-alpha hashicorp/kubernetes