### PR TITLE
BET-7677: Create two Service Accounts per project

### DIFF
--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -1,0 +1,22 @@
+---
+formatter: "markdown"
+version: ">= 0.17.0"
+header-from: main.tf
+output:
+  mode: inject
+  file: README.md
+settings:
+  anchor: true
+  color: true
+  default: true
+  description: false
+  escape: true
+  hide-empty: false
+  html: true
+  indent: 2
+  lockfile: true
+  read-comments: true
+  required: true
+  sensitive: true
+  type: true
+

--- a/grafana-config/README.md
+++ b/grafana-config/README.md
@@ -1,28 +1,39 @@
+<!-- BEGIN_TF_DOCS -->
+# MonoM's Grafana Config Module
+
+A module for configuring grafana
+
+**NOTE**: This module is highly opinionated and it may not
+suit for your particular use case.
+
 ## Requirements
 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14 |
+| <a name="requirement_grafana"></a> [grafana](#requirement\_grafana) | >= 3.4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | n/a |
-| <a name="provider_grafana"></a> [grafana](#provider\_grafana) | n/a |
+| <a name="provider_grafana"></a> [grafana](#provider\_grafana) | >= 3.4.0 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_sa_bigquery"></a> [sa\_bigquery](#module\_sa\_bigquery) | github.com/ThingsO2/monom-terraform-modules//service-account | v1.2.0 |
+| <a name="module_sa_bigquery_editor"></a> [sa\_bigquery\_editor](#module\_sa\_bigquery\_editor) | github.com/ThingsO2/monom-terraform-modules//service-account | v3.4.0 |
+| <a name="module_sa_bigquery_read"></a> [sa\_bigquery\_read](#module\_sa\_bigquery\_read) | github.com/ThingsO2/monom-terraform-modules//service-account | v3.4.0 |
 
 ## Resources
 
 | Name | Type |
 |------|------|
-| [google_bigquery_table_iam_member.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/bigquery_table_iam_member) | resource |
+| [google_bigquery_table_iam_member.reader](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/bigquery_table_iam_member) | resource |
+| [google_bigquery_table_iam_member.writer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/bigquery_table_iam_member) | resource |
 | [grafana_dashboard.general](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/dashboard) | resource |
 | [grafana_data_source.bigquery](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/data_source) | resource |
 | [grafana_folder.general](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/folder) | resource |
@@ -33,11 +44,12 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_client_project_id"></a> [client\_project\_id](#input\_client\_project\_id) | n/a | `string` | `""` | no |
-| <a name="input_grafana_dashboards"></a> [grafana\_dashboards](#input\_grafana\_dashboards) | n/a | `list(string)` | `[]` | no |
-| <a name="input_grafana_folder_name"></a> [grafana\_folder\_name](#input\_grafana\_folder\_name) | n/a | `string` | n/a | yes |
-| <a name="input_project"></a> [project](#input\_project) | Project name | `string` | n/a | yes |
+| <a name="input_client_project_id"></a> [client\_project\_id](#input\_client\_project\_id) | ID of the client's project in MonoM's platform. | `string` | `""` | no |
+| <a name="input_grafana_dashboards"></a> [grafana\_dashboards](#input\_grafana\_dashboards) | List of Grafana dashboards to add to the project. | `list(string)` | `[]` | no |
+| <a name="input_grafana_folder_name"></a> [grafana\_folder\_name](#input\_grafana\_folder\_name) | Name for the folder which stores the Dashboards in Grafana. | `string` | n/a | yes |
+| <a name="input_project"></a> [project](#input\_project) | GCP project name. | `string` | n/a | yes |
 
 ## Outputs
 
 No outputs.
+<!-- END_TF_DOCS -->

--- a/grafana-config/README.md
+++ b/grafana-config/README.md
@@ -11,14 +11,14 @@ suit for your particular use case.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14 |
-| <a name="requirement_grafana"></a> [grafana](#requirement\_grafana) | >= 3.4.0 |
+| <a name="requirement_grafana"></a> [grafana](#requirement\_grafana) | >= 3.6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | n/a |
-| <a name="provider_grafana"></a> [grafana](#provider\_grafana) | >= 3.4.0 |
+| <a name="provider_grafana"></a> [grafana](#provider\_grafana) | >= 3.6.0 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules
@@ -47,6 +47,7 @@ suit for your particular use case.
 | <a name="input_client_project_id"></a> [client\_project\_id](#input\_client\_project\_id) | ID of the client's project in MonoM's platform. | `string` | `""` | no |
 | <a name="input_grafana_dashboards"></a> [grafana\_dashboards](#input\_grafana\_dashboards) | List of Grafana dashboards to add to the project. | `list(string)` | `[]` | no |
 | <a name="input_grafana_folder_name"></a> [grafana\_folder\_name](#input\_grafana\_folder\_name) | Name for the folder which stores the Dashboards in Grafana. | `string` | n/a | yes |
+| <a name="input_grafana_org_id"></a> [grafana\_org\_id](#input\_grafana\_org\_id) | The ID of the Grafana Organization where we want to operate. | `string` | n/a | yes |
 | <a name="input_project"></a> [project](#input\_project) | GCP project name. | `string` | n/a | yes |
 
 ## Outputs

--- a/grafana-config/main.tf
+++ b/grafana-config/main.tf
@@ -8,10 +8,12 @@
  */
 
 resource "grafana_folder" "general" {
-  title = var.grafana_folder_name
+  title  = var.grafana_folder_name
+  org_id = var.grafana_org_id
 }
 
 resource "grafana_dashboard" "general" {
+  org_id   = var.grafana_org_id
   for_each = zipmap(var.grafana_dashboards, var.grafana_dashboards)
 
   config_json = templatefile(each.value, {
@@ -88,8 +90,9 @@ resource "google_bigquery_table_iam_member" "writer" {
 
 resource "grafana_data_source" "bigquery" {
 
-  name = "BigQuery${var.client_project_id}"
-  type = "doitintl-bigquery-datasource"
+  name   = "BigQuery${var.client_project_id}"
+  type   = "doitintl-bigquery-datasource"
+  org_id = var.grafana_org_id
 
   json_data_encoded = jsonencode({
     "token_uri"           = "https://oauth2.googleapis.com/token"

--- a/grafana-config/main.tf
+++ b/grafana-config/main.tf
@@ -1,3 +1,12 @@
+/**
+ * # MonoM's Grafana Config Module
+ *
+ * A module for configuring grafana
+ *
+ * **NOTE**: This module is highly opinionated and it may not 
+ * suit for your particular use case.
+ */
+
 resource "grafana_folder" "general" {
   title = var.grafana_folder_name
 }
@@ -7,16 +16,32 @@ resource "grafana_dashboard" "general" {
 
   config_json = templatefile(each.value, {
     datasource_type = grafana_data_source.bigquery.type
-    datasource_uid   = grafana_data_source.bigquery.uid
+    datasource_uid  = grafana_data_source.bigquery.uid
   })
   folder = grafana_folder.general.id
 }
 
-module "sa_bigquery" {
-  source = "github.com/ThingsO2/monom-terraform-modules//service-account?ref=v1.2.0"
+module "sa_bigquery_read" {
+  source = "github.com/ThingsO2/monom-terraform-modules//service-account?ref=v3.4.0"
+  # source = "../../monom-terraform-modules/service-account/"
 
-  account_id   = "bq-ds-${var.client_project_id}"
-  display_name = "BigQuery DataSource SA"
+  account_id   = "bqdsr-${var.client_project_id}"
+  display_name = "BigQuery DataSource Reader SA"
+  description  = "Service Account with read-only access for project ${var.client_project_id}"
+  project      = var.project
+
+  sa_role_binding = [
+    "roles/bigquery.jobUser",
+  ]
+}
+
+module "sa_bigquery_editor" {
+  source = "github.com/ThingsO2/monom-terraform-modules//service-account?ref=v3.4.0"
+  # source = "../../monom-terraform-modules/service-account/"
+
+  account_id   = "bqdse-${var.client_project_id}"
+  display_name = "BigQuery DataSource Editor SA"
+  description  = "Service Account with write access for project ${var.client_project_id}"
   project      = var.project
 
   sa_role_binding = [
@@ -44,28 +69,37 @@ data "terraform_remote_state" "bigquery" {
   }
 }
 
-resource "google_bigquery_table_iam_member" "this" {
+resource "google_bigquery_table_iam_member" "reader" {
   project    = data.terraform_remote_state.project.outputs.project_id
   dataset_id = data.terraform_remote_state.bigquery.outputs.dataset_id
   table_id   = var.client_project_id
   role       = "roles/bigquery.dataViewer"
-  member     = "serviceAccount:${module.sa_bigquery.email}"
+  member     = "serviceAccount:${module.sa_bigquery_read.email}"
 }
+
+resource "google_bigquery_table_iam_member" "writer" {
+  project    = data.terraform_remote_state.project.outputs.project_id
+  dataset_id = data.terraform_remote_state.bigquery.outputs.dataset_id
+  table_id   = var.client_project_id
+  role       = "roles/bigquery.dataEditor"
+  member     = "serviceAccount:${module.sa_bigquery_editor.email}"
+}
+
 
 resource "grafana_data_source" "bigquery" {
 
   name = "BigQuery${var.client_project_id}"
   type = "doitintl-bigquery-datasource"
 
-  json_data {
-    token_uri           = "https://oauth2.googleapis.com/token"
-    authentication_type = "jwt"
-    default_project     = var.project
-    client_email        = module.sa_bigquery.email
-    default_region      = "EU"
-  }
+  json_data_encoded = jsonencode({
+    "token_uri"           = "https://oauth2.googleapis.com/token"
+    "authentication_type" = "jwt"
+    "default_project"     = "${var.project}"
+    "client_email"        = "${module.sa_bigquery_read.email}"
+    "default_region"      = "EU"
+  })
 
-  secure_json_data {
-    private_key = jsondecode(module.sa_bigquery.key_decode)["private_key"]
-  }
+  secure_json_data_encoded = jsonencode({
+    "private_key" = jsondecode(module.sa_bigquery_read.key_decode)["private_key"]
+  })
 }

--- a/grafana-config/variables.tf
+++ b/grafana-config/variables.tf
@@ -8,6 +8,11 @@ variable "grafana_folder_name" {
   description = "Name for the folder which stores the Dashboards in Grafana."
 }
 
+variable "grafana_org_id" {
+  type        = string
+  description = "The ID of the Grafana Organization where we want to operate."
+}
+
 variable "grafana_dashboards" {
   type        = list(string)
   default     = []

--- a/grafana-config/variables.tf
+++ b/grafana-config/variables.tf
@@ -1,18 +1,21 @@
 variable "project" {
   type        = string
-  description = "Project name"
+  description = "GCP project name."
 }
 
 variable "grafana_folder_name" {
-  type = string
+  type        = string
+  description = "Name for the folder which stores the Dashboards in Grafana."
 }
 
 variable "grafana_dashboards" {
-  type    = list(string)
-  default = []
+  type        = list(string)
+  default     = []
+  description = "List of Grafana dashboards to add to the project."
 }
 
 variable "client_project_id" {
-  type    = string
-  default = ""
+  type        = string
+  default     = ""
+  description = "ID of the client's project in MonoM's platform."
 }

--- a/grafana-config/versions.tf
+++ b/grafana-config/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     grafana = {
       source  = "grafana/grafana"
-      version = ">= 3.4.0"
+      version = ">= 3.6.0"
     }
   }
   required_version = ">= 0.14"

--- a/grafana-config/versions.tf
+++ b/grafana-config/versions.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     grafana = {
-      source = "grafana/grafana"
+      source  = "grafana/grafana"
+      version = ">= 3.4.0"
     }
   }
   required_version = ">= 0.14"


### PR DESCRIPTION
Changes:
* This module creates two SAs instead of one. A Read-Only SA and an Editor one.
* Updated docs. Terraform-docs configuration has been added.
* The SA's naming scheme has changed due to SA name length restrictions.