### PR TITLE
feat: add enagas postgres to import resource manually to remote state

### DIFF
--- a/sql-k8s-connection/README.md
+++ b/sql-k8s-connection/README.md
@@ -27,6 +27,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_alert_policies"></a> [alert\_policies](#input\_alert\_policies) | n/a | <pre>list(object({<br>    display_name = string<br>    conditions = list(object({<br>      display_name     = string<br>      metric_type      = string # https://cloud.google.com/sql/docs/mysql/admin-api/metrics<br>      duration         = string<br>      threshold_value  = string<br>      alignment_period = string<br>    }))<br>  }))</pre> | `null` | no |
+| <a name="input_authorized_networks"></a> [authorized\_networks](#input\_authorized\_networks) | n/a | <pre>list(object({ <br>    net_name = string <br>     ip = string  <br>  }))</pre> | `null` | no |
 | <a name="input_database_instance_name"></a> [database\_instance\_name](#input\_database\_instance\_name) | n/a | `string` | n/a | yes |
 | <a name="input_database_tier"></a> [database\_tier](#input\_database\_tier) | n/a | `string` | `"db-f1-micro"` | no |
 | <a name="input_database_version"></a> [database\_version](#input\_database\_version) | n/a | `string` | n/a | yes |

--- a/sql-k8s-connection/main.tf
+++ b/sql-k8s-connection/main.tf
@@ -20,6 +20,16 @@ resource "google_sql_database_instance" "this" {
     ip_configuration {
       ipv4_enabled    = true
       private_network = var.network_id
+      
+      dynamic "authorized_networks" {
+        for_each = var.authorized_networks
+        iterator = authorized_networks
+
+        content {
+          name  = authorized_networks.value.net_name
+          value = authorized_networks.value.ip
+        }
+      }
     }
     disk_type = var.disk_type
 

--- a/sql-k8s-connection/variables.tf
+++ b/sql-k8s-connection/variables.tf
@@ -64,3 +64,11 @@ variable "alert_policies" {
   }))
   default = null
 }
+
+variable "authorized_networks" {
+  type = list(object({
+    net_name = string
+    ip = string
+  }))
+  default = null
+}


### PR DESCRIPTION
**Title:** Add authorized_networks variable

**Description:**

* **Summary:** Add authorized_networks variable
* **Motivation:** In case some authorised IPs are known for direct connection to the instance, it is now possible to define them in terraform.
* **Changes:**
    * Add  authorized_networks variable to declare which IPs are allow to connect directly.

