### PR TITLE
feat: upgrade cloudflare provider from 3.22.0 to 5.2.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,5 @@
 ---
-name: Release_call
+name: job
 on:
   pull_request:
     branches:
@@ -7,7 +7,61 @@ on:
   push:
     branches:
       - main
+
 jobs:
   job:
-    uses: ThingsO2/monom-ci-workflows/.github/workflows/release-workflow.yaml@main
-    secrets: inherit
+    name: Check release
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    outputs:
+      monom: ${{ steps.monom.outputs.permitted }}
+      externals: ${{ steps.externals.outputs.permitted }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Analyze commits
+        id: next_release_version
+        run: |
+          npm install --save-dev semantic-release@18 > /dev/null
+          sed -i "s#const {isCi, branch, prBranch, isPr} = context.envCi;#const {isCi, branch, prBranch, isPr} = {isCi: false, branch: '${{ github.event.pull_request.head.ref }}', prBranch: undefined, isPr: undefined};#" node_modules/semantic-release/index.js
+          echo "TAG=$(npx semantic-release -b ${{ github.event.pull_request.head.ref }}  -p '@semantic-release/commit-analyzer' --dry-run --no-ci | grep -oiP 'the next release version is *\K.*')" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create comment if analyze commits fails
+        uses: peter-evans/create-or-update-comment@v2
+        if: steps.next_release_version.outputs.TAG == ''
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            Commits message format don't use Angular Commit Message Conventions and it's necessary to generate the next tag
+
+            https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines
+
+      - name: Cancel if analyze commits fails
+        if: steps.next_release_version.outputs.TAG == ''
+        uses: actions/github-script@v6
+        with:
+          script: |
+            core.setFailed("Commits message format don't use Angular Commit Message Conventions and it's necessary to generate the next tag")
+
+  release:
+    name: Generate release
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Semantic Release
+        id: release
+        uses: cycjimmy/semantic-release-action@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.KINGKONG_GITHUB_TOKEN }}
+      

--- a/gcp-k8s-public-app/main.tf
+++ b/gcp-k8s-public-app/main.tf
@@ -74,14 +74,11 @@ resource "google_compute_global_address" "this" {
   address_type = "EXTERNAL"
 }
 
-data "cloudflare_zone" "this" {
-  name = "monom.ai"
-}
-resource "cloudflare_record" "this" {
-  zone_id = data.cloudflare_zone.this.id
+resource "cloudflare_dns_record" "this" {
+  zone_id = "b9e914ceb58779b21228102ee51301a9"
   name    = "${local.domain}.${var.root_domain}."
-  type    = "A"
-  ttl     = "300"
+  content = google_compute_global_address.this.address
   proxied = var.proxied
-  value   = google_compute_global_address.this.address
+  ttl = 300
+  type = "A"
 }


### PR DESCRIPTION
**Title:** Upgrade cloudflare provider from 3.22.0 to 5.2.0.

**Description:**

* **Summary:**  Upgrade cloudflare provider from 3.22.0 to 5.2.0.
* **Motivation:** Incompatibilities with 3.22.0 version when using Api Token as auth method.
* **Changes:**
    * Upgrade cloudflare provider  version.
    * Update cloudflare_dns_record resource.